### PR TITLE
fix: skip prepending issue number if already in commit message

### DIFF
--- a/commit_msg_issue_number_prepend.sh
+++ b/commit_msg_issue_number_prepend.sh
@@ -25,5 +25,10 @@ fi
 
 
 if [ -n "$ISSUE_NUMBER" ]; then
-    echo "$REPO_PREPEND#$ISSUE_NUMBER" `cat $1`  > "$1"
+    COMMIT_MSG=$(cat "$1")
+    # Check if issue number is already in the commit message
+    if echo "$COMMIT_MSG" | grep -qE "(^|[^0-9])#$ISSUE_NUMBER([^0-9]|$)"; then
+        exit 0
+    fi
+    echo "$REPO_PREPEND#$ISSUE_NUMBER" "$COMMIT_MSG" > "$1"
 fi


### PR DESCRIPTION
## Summary
- Fixes duplicate issue number prepending when commit message already contains the issue reference
- Adds regex check to detect existing `#ISSUE_NUMBER` pattern before prepending

## Test plan
- [x] Verified pre-commit hook passes
- [ ] Test with commit that already has issue number in message
- [ ] Test with commit that doesn't have issue number

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where commit message issue number prepends could create duplicates. The system now checks for existing issue numbers before prepending to prevent duplication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->