### PR TITLE
ci: fix environment detection for workflow_dispatch

### DIFF
--- a/.github/workflows/lambda_flow.yml
+++ b/.github/workflows/lambda_flow.yml
@@ -94,9 +94,11 @@ jobs:
           else
           deploy_environment=qa
           fi
-          elif [ "${{ github.event_name }}" == "push" ]; then
-          # If the PR is merged, deploy to the prod environment
+          elif [ "${{ github.ref }}" == "refs/heads/main" ]; then
+          # Push to main or workflow_dispatch on main → deploy to prod
               deploy_environment=prod
+          else
+              deploy_environment=default
           fi
           echo "deploy_environment:$deploy_environment"
           echo "deploy_environment=$deploy_environment" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Change `lambda_flow.yml` environment logic from checking `github.event_name == push` to checking `github.ref == refs/heads/main`
- This correctly maps `workflow_dispatch` on main to prod (previously resulted in empty environment, falling through to `default`)
- Matches the pattern already used in `pylibs_flow.yml`
- Adds explicit `default` fallback for non-main branches

**Context:** Companion to hipponot/microservices PR that removes auto-deploy on push to main. This fix ensures manual workflow_dispatch correctly targets prod.

## Test plan

- [ ] Verify workflow_dispatch on main sets deploy_environment=prod
- [ ] Verify PR events still set deploy_environment=qa (or default for drafts)
- [ ] Verify non-main branch dispatch sets deploy_environment=default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline configuration to trigger production deployments based on main branch activities rather than general push events, improving deployment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->